### PR TITLE
change owner of active_low as well on export

### DIFF
--- a/gpio/gpio.c
+++ b/gpio/gpio.c
@@ -500,6 +500,8 @@ void doExport (int argc, char *argv [])
   sprintf (fName, "/sys/class/gpio/gpio%d/edge", pin) ;
   changeOwner (argv [0], fName) ;
 
+  sprintf (fName, "/sys/class/gpio/gpio%d/active_low", pin) ;
+  changeOwner (argv [0], fName) ;
 }
 
 


### PR DESCRIPTION
This allows the user to set active_low of the pin after export